### PR TITLE
Use ToDetailString for arguments error message

### DIFF
--- a/native_mate/arguments.cc
+++ b/native_mate/arguments.cc
@@ -11,16 +11,11 @@ namespace mate {
 
 namespace {
 
-std::string V8TypeAsString(v8::Local<v8::Value> value) {
-  if (value.IsEmpty())
-    return "<empty handle>";
-  if (value->IsUndefined())
-    return "undefined";
-  if (value->IsNull())
-    return "null";
+std::string V8TypeAsString(v8::Isolate* isolate, v8::Local<v8::Value> value) {
+  v8::MaybeLocal<v8::String> details = value->ToDetailString(isolate);
   std::string result;
-  if (!ConvertFromV8(NULL, value, &result))
-    return std::string();
+  if (!details.IsEmpty())
+    ConvertFromV8(isolate, details.ToLocalChecked(), &result);
   return result;
 }
 
@@ -55,7 +50,7 @@ v8::Local<v8::Value> Arguments::ThrowError() const {
 
   return ThrowTypeError(base::StringPrintf(
       "Error processing argument at index %d, conversion failure from %s",
-      next_, V8TypeAsString((*info_)[next_]).c_str()));
+      next_, V8TypeAsString(isolate_, (*info_)[next_]).c_str()));
 }
 
 v8::Local<v8::Value> Arguments::ThrowError(const std::string& message) const {

--- a/native_mate/arguments.cc
+++ b/native_mate/arguments.cc
@@ -12,6 +12,8 @@ namespace mate {
 namespace {
 
 std::string V8TypeAsString(v8::Isolate* isolate, v8::Local<v8::Value> value) {
+  if (value.IsEmpty())
+    return "<empty handle>";
   v8::MaybeLocal<v8::String> details = value->ToDetailString(isolate);
   std::string result;
   if (!details.IsEmpty())


### PR DESCRIPTION
Previously many types weren't represented when conversion to a string failed.

This pull request changes the error message to use the `ToDetailString` string from the v8 value.

Previous messages for booleans, numbers, and Promises, etc.:

> Error processing argument at index %d, conversion failure from 

New messages for booleans, numbers, and Promises, etc.:

> Error processing argument at index 0, conversion failure from `#<Promise>`
> Error processing argument at index 0, conversion failure from 100
> Error processing argument at index 0, conversion failure from false
