### PR TITLE
Add a converter for `nullptr_t`

### DIFF
--- a/native_mate/converter.h
+++ b/native_mate/converter.h
@@ -41,6 +41,13 @@ struct Converter<void*> {
 };
 
 template<>
+struct Converter<std::nullptr_t> {
+  static v8::Local<v8::Value> ToV8(v8::Isolate* isolate, std::nullptr_t val) {
+    return v8::Null(isolate);
+  }
+};
+
+template<>
 struct Converter<bool> {
   static v8::Local<v8::Value> ToV8(v8::Isolate* isolate,
                                     bool val);


### PR DESCRIPTION
This converter allows for easy conversion from a null pointer literal (`nullptr`) to a V8 `null`.