### PR TITLE
Upstream Muon changes to avoid crashing

### DIFF
--- a/native_mate/function_template.h
+++ b/native_mate/function_template.h
@@ -21,6 +21,9 @@ namespace internal {
 
 struct Destroyable {
   static void Destroy(Arguments* args) {
+    if (IsDestroyed(args))
+      return;
+
     v8::Local<v8::Object> holder = args->GetHolder();
     delete static_cast<WrappableBase*>(
         holder->GetAlignedPointerFromInternalField(0));

--- a/native_mate/wrappable.cc
+++ b/native_mate/wrappable.cc
@@ -24,8 +24,11 @@ WrappableBase::~WrappableBase() {
 }
 
 v8::Local<v8::Object> WrappableBase::GetWrapper() {
-  CHECK(!wrapper_.IsEmpty());
-  return v8::Local<v8::Object>::New(isolate_, wrapper_);
+  DCHECK(!wrapper_.IsEmpty());
+  if (!wrapper_.IsEmpty())
+    return v8::Local<v8::Object>::New(isolate_, wrapper_);
+  else
+    return v8::Local<v8::Object>();
 }
 
 void WrappableBase::InitWith(v8::Isolate* isolate,


### PR DESCRIPTION
https://github.com/electron/electron/issues/10527 and possibly https://github.com/electron/electron/issues/10433 make me think something is subtly broken in native-mate.  As a workaround, how about we upstream these changes from Muon: brave/muon@58c0ec0#diff-a31bffb28ca1eed32c06c2d6b8b53f45 brave/muon#323
