### PR TITLE
Remove WrappableBase::GetWrapper() DCHECK

### DIFF
--- a/native_mate/wrappable.cc
+++ b/native_mate/wrappable.cc
@@ -24,7 +24,6 @@ WrappableBase::~WrappableBase() {
 }
 
 v8::Local<v8::Object> WrappableBase::GetWrapper() {
-  DCHECK(!wrapper_.IsEmpty());
   if (!wrapper_.IsEmpty())
     return v8::Local<v8::Object>::New(isolate_, wrapper_);
   else


### PR DESCRIPTION
The existing`DCHECK` can fail at cases when:

---

As reported in https://github.com/electron/electron/issues/9487:

In `WrappableBase::FirstWeakCallback()`, the `wrapper_` is reset 🏷 and the `WrappableBase::SecondWeakCallback()` is scheduled.

https://github.com/electron/native-mate/blob/88fa343387c46d6c59edcb0e1d16611eb17b922c/native_mate/wrappable.cc#L59-L69

So when [wrappable.cc#L75](https://github.com/electron/native-mate/blob/master/native_mate/wrappable.cc#L75) is executed...

https://github.com/electron/native-mate/blob/88fa343387c46d6c59edcb0e1d16611eb17b922c/native_mate/wrappable.cc#L71-L76

The destructor (for example) at `WebContents` will try to call methods like `?::Emit()`, here indirectly through `WebContents::RenderViewDeleted()`.

- `WebContents::~WebContents`: [atom/browser/api/atom_api_web_contents.cc#L446-L470](https://github.com/electron/electron/blob/6b408de88420d81d9f98eb54cc4a6549653b3ed9/atom/browser/api/atom_api_web_contents.cc#L446-L470)

- `WebContents::RenderViewDeleted()`: [atom/browser/api/atom_api_web_contents.cc#L745-L747](https://github.com/electron/electron/blob/6b408de88420d81d9f98eb54cc4a6549653b3ed9/atom/browser/api/atom_api_web_contents.cc#L745-L747)

Since `WebContents`'s prototype is set to `EventEmitter`, `EventEmitter::Emit()` is called at [atom/browser/api/event_emitter.h#L68-L89](https://github.com/electron/electron/blob/b429dafa381bb9685e347f5547a03861ab4f2b19/atom/browser/api/event_emitter.h#L68-L89). There in `EventEmitter::EmitWithSender()` tries to get the wrapper of the destructing object on [#82](https://github.com/electron/electron/blob/b429dafa381bb9685e347f5547a03861ab4f2b19/atom/browser/api/event_emitter.h#L82)...

https://github.com/electron/native-mate/blob/40bd3336a5ce6ee0323b50c33641bb2e734f7f51/native_mate/wrappable.cc#L26-L32

... where there's a `DCHECK` on the `wrapper_` that's already reset. 🏷

---

Alternatively a similar issue can arise...?

https://github.com/electron/native-mate/blob/88fa343387c46d6c59edcb0e1d16611eb17b922c/native_mate/wrappable.h#L52-L67

`wrapper_` would probably never be set with some value... and could similarly cause fault on `DCHECK` whenever method calls like `?::Emit()` uses `WrappableBase::GetWrapper()`.

---

cc: @alexeykuzmin