### PR TITLE
GetWrapper should be const

### DIFF
--- a/native_mate/wrappable.cc
+++ b/native_mate/wrappable.cc
@@ -23,7 +23,7 @@ WrappableBase::~WrappableBase() {
   wrapper_.Reset();
 }
 
-v8::Local<v8::Object> WrappableBase::GetWrapper() {
+v8::Local<v8::Object> WrappableBase::GetWrapper() const {
   if (!wrapper_.IsEmpty())
     return v8::Local<v8::Object>::New(isolate_, wrapper_);
   else

--- a/native_mate/wrappable_base.h
+++ b/native_mate/wrappable_base.h
@@ -31,7 +31,7 @@ class WrappableBase {
   virtual ~WrappableBase();
 
   // Retrieve the v8 wrapper object cooresponding to this object.
-  v8::Local<v8::Object> GetWrapper();
+  v8::Local<v8::Object> GetWrapper() const;
 
   // Returns the Isolate this object is created in.
   v8::Isolate* isolate() const { return isolate_; }


### PR DESCRIPTION
It used to be non-const because it modified `wrapper_` before, now since it is readonly it should be const.