### PR TITLE
Revert "Address breaking API"

### DIFF
--- a/native_mate/constructor.h
+++ b/native_mate/constructor.h
@@ -127,7 +127,7 @@ MATE_METHOD_RETURN_TYPE InvokeNew(const base::Callback<Sig>& factory,
   WrappableBase* object;
   {
     // Don't continue if the constructor throws an exception.
-    v8::TryCatch try_catch(isolate);
+    v8::TryCatch try_catch;
     object = internal::InvokeFactory(args, factory);
     if (try_catch.HasCaught()) {
       try_catch.ReThrow();

--- a/native_mate/object_template_builder.h
+++ b/native_mate/object_template_builder.h
@@ -69,7 +69,7 @@ class ObjectTemplateBuilder {
  public:
   explicit ObjectTemplateBuilder(
       v8::Isolate* isolate,
-      v8::Local<v8::ObjectTemplate> templ);
+      v8::Local<v8::ObjectTemplate> templ = v8::ObjectTemplate::New());
   ~ObjectTemplateBuilder();
 
   // It's against Google C++ style to return a non-const ref, but we take some


### PR DESCRIPTION
This reverts commit e20cf8687e5e0e1b807ced4c90695ee22de220b8.

We want this for Chromium 66, but it breaks builds on  `electron/electron` `master` so if we have it there now it blocks any other updates to `native_mate` before C66 is merged in. 

Once this is merged, i'll open up another PR to add it back in, which we can then merge post-C66. 

This should also fix failing CI. 

/cc @MarshallOfSound @nitsakh 