### PR TITLE
Ensure all promises are persisted on the heap

### DIFF
--- a/native_mate/promise.cc
+++ b/native_mate/promise.cc
@@ -12,34 +12,26 @@ Promise::Promise()
 
 Promise::Promise(v8::Isolate* isolate)
     : isolate_(isolate) {
-  resolver_ = v8::Promise::Resolver::New(isolate);
+  handle_ = new RefCountedPersistent<v8::Promise::Resolver>(isolate, v8::Promise::Resolver::New(isolate));
 }
 
 Promise::~Promise() {
-}
-
-Promise Promise::Create(v8::Isolate* isolate) {
-  return Promise(isolate);
-}
-
-Promise Promise::Create() {
-  return Promise::Create(v8::Isolate::GetCurrent());
 }
 
 void Promise::RejectWithErrorMessage(const std::string& string) {
   v8::Local<v8::String> error_message =
       v8::String::NewFromUtf8(isolate(), string.c_str());
   v8::Local<v8::Value> error = v8::Exception::Error(error_message);
-  resolver_->Reject(mate::ConvertToV8(isolate(), error));
+  GetHandle()->Reject(mate::ConvertToV8(isolate(), error));
 }
 
-v8::Local<v8::Object> Promise::GetHandle() const {
-  return resolver_->GetPromise();
+v8::Local<v8::Promise::Resolver> Promise::GetHandle() const {
+  return handle_->NewHandle();
 }
 
 v8::Local<v8::Value> Converter<Promise>::ToV8(v8::Isolate* isolate,
                                                   Promise val) {
-  return val.GetHandle();
+  return val.GetHandle()->GetPromise();
 }
 
 }  // namespace mate

--- a/native_mate/promise.h
+++ b/native_mate/promise.h
@@ -6,6 +6,7 @@
 #define NATIVE_MATE_PROMISE_H_
 
 #include "native_mate/converter.h"
+#include "native_mate/scoped_persistent.h"
 
 namespace mate {
 
@@ -19,17 +20,18 @@ class Promise {
   static Promise Create();
 
   v8::Isolate* isolate() const { return isolate_; }
+  bool IsEmpty() const { return isolate() == NULL; }
 
-  virtual v8::Local<v8::Object> GetHandle() const;
+  virtual v8::Local<v8::Promise::Resolver> GetHandle() const;
 
   template<typename T>
   void Resolve(T* value) {
-    resolver_->Resolve(mate::ConvertToV8(isolate(), value));
+    GetHandle()->Resolve(mate::ConvertToV8(isolate(), value));
   }
 
   template<typename T>
   void Reject(T* value) {
-    resolver_->Reject(mate::ConvertToV8(isolate(), value));
+    GetHandle()->Reject(mate::ConvertToV8(isolate(), value));
   }
 
   void RejectWithErrorMessage(const std::string& error);
@@ -38,7 +40,7 @@ class Promise {
   v8::Isolate* isolate_;
 
  private:
-  v8::Local<v8::Promise::Resolver> resolver_;
+  scoped_refptr<RefCountedPersistent<v8::Promise::Resolver>> handle_;
 };
 
 template<>


### PR DESCRIPTION
Unlike dictionaries, there is no use case for a limited lifetime promise. The lifetime of promises can extend the lifetime of local scopes and normally have to.