### PR TITLE
Don't copy things in Dictionary::Set

### DIFF
--- a/native_mate/converter.h
+++ b/native_mate/converter.h
@@ -343,7 +343,7 @@ struct ToV8Traits<T, false> {
 
 template <typename T>
 bool TryConvertToV8(v8::Isolate* isolate,
-                    T input,
+                    const T& input,
                     v8::Local<v8::Value>* output) {
   return ToV8Traits<T>::TryConvertToV8(isolate, input, output);
 }

--- a/native_mate/dictionary.h
+++ b/native_mate/dictionary.h
@@ -69,7 +69,7 @@ class Dictionary {
   }
 
   template<typename T>
-  bool Set(const base::StringPiece& key, T val) {
+  bool Set(const base::StringPiece& key, const T& val) {
     v8::Local<v8::Value> v8_value;
     if (!TryConvertToV8(isolate_, val, &v8_value))
       return false;


### PR DESCRIPTION
I'm not sure why this isn't done this way in `gin` upstream, so perhaps I'm missing something. Without this, though, electron tries to call the copy constructor of `net::CertPrincipal`, which doesn't have a copy constructor—it isn't marked `DISALLOW_COPY_AND_ASSIGN` in Chromium, but it should be.